### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Install dependencies with [Bundler](https://bundler.io)
     
 Now you need to register your Mac with you Hue. Press the button on the bridge, then:
 
-    ruby eurovisionhue.rb
+    bundle exec ruby eurovisionhue.rb
 
 You only need to do that the first time you run it.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ most recently mentioned in that live blog.
 
 Will probably work on most Macs.
 
-Install dependencies: `bundle`
+Install dependencies with [Bundler](https://bundler.io)
 
     bundle
     


### PR DESCRIPTION
Updates the README to dedupe the Bundler reference and recommend execution through Bundler rather than around it.
