### PR TITLE
Prevents crash when colour count < light count.

### DIFF
--- a/eurovisionhue.rb
+++ b/eurovisionhue.rb
@@ -68,7 +68,11 @@ while true do
     colours = Miro::DominantColors.new("flags/#{new_country}.png")
     hue.lights.each_with_index do |light, i|
       light.on!
-      rgb = colours.to_rgb[i]
+      if i < colours.to_rgb.count
+        rgb = colours.to_rgb[i]
+      else
+        rgb = colours.to_rgb[i-colours.to_rgb.count]
+      end
       target_colour = Color::RGB.new(rgb[0], rgb[1], rgb[2])
       puts "Transitioning #{light.name} to #{rgb}"
       light.set_state(colour_to_hue(target_colour), transition: 5)


### PR DESCRIPTION
It seems to occasionally crash due array indexing with  
`undefined method `[]' for nil:NilClass (NoMethodError)`  

`Miro::DominantColors` can return less colours than the number of lights. I'm a Ruby beginner but I've added a rough wrap around to reduce the chance of it happening. 