### PR TITLE
Better Fix for crash when colour count < light count.

### DIFF
--- a/eurovisionhue.rb
+++ b/eurovisionhue.rb
@@ -71,7 +71,7 @@ while true do
       if i < colours.to_rgb.count
         rgb = colours.to_rgb[i]
       else
-        rgb = colours.to_rgb[i-colours.to_rgb.count]
+        rgb = colours.to_rgb[i % colours.to_rgb.count]
       end
       target_colour = Color::RGB.new(rgb[0], rgb[1], rgb[2])
       puts "Transitioning #{light.name} to #{rgb}"


### PR DESCRIPTION
Repeats colour usage as many times as needed, instead of up to twice. #6
It may be useful next year.  